### PR TITLE
Roslaunch compatibility and module paths

### DIFF
--- a/launch/mesh_completion_server.launch
+++ b/launch/mesh_completion_server.launch
@@ -1,6 +1,6 @@
 
 <launch>
-	<node pkg="pc_object_completion_cnn" type="mesh_completion_server.py" name="mesh_completion_server" args="depth">
+	<node pkg="pc_object_completion_cnn" type="mesh_completion_server.py" name="pc_cnn_mesh" args="depth">
 		<!-- arguments define which CNN gets used, options are depth and depth_and_tactile -->
 	</node>
 	depth

--- a/launch/mesh_completion_server.launch
+++ b/launch/mesh_completion_server.launch
@@ -1,0 +1,7 @@
+
+<launch>
+	<node pkg="pc_object_completion_cnn" type="mesh_completion_server.py" name="mesh_completion_server" args="depth">
+		<!-- arguments define which CNN gets used, options are depth and depth_and_tactile -->
+	</node>
+	depth
+</launch>

--- a/scripts/shape_completion_server/mesh_completion_server.py
+++ b/scripts/shape_completion_server/mesh_completion_server.py
@@ -117,7 +117,7 @@ class MeshCompletionServer(object):
             dtype=np.float32)
         batch_x[0, :, :, :, 0] = partial_vox.data
 
-        
+
         if self.flip_batch_x:
             rospy.loginfo("Flipping Batch X, if performance is poor,\
             try setting flip_batch_x=False")
@@ -213,15 +213,17 @@ if __name__ == "__main__":
     parser.add_argument(
         "__log",
         type=str,
+        default=" ",
         help=
         ""
     )
     parser.add_argument(
         "__name",
         type=str,
+        default=" ",
         help=
         ""
-    )    
+    )
     args = parser.parse_args()
     cnns = {
         "depth": {

--- a/scripts/shape_completion_server/mesh_completion_server.py
+++ b/scripts/shape_completion_server/mesh_completion_server.py
@@ -117,7 +117,7 @@ class MeshCompletionServer(object):
             dtype=np.float32)
         batch_x[0, :, :, :, 0] = partial_vox.data
 
-        
+
         if self.flip_batch_x:
             rospy.loginfo("Flipping Batch X, if performance is poor,\
             try setting flip_batch_x=False")
@@ -200,8 +200,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "ns",
         type=str,
-        help=
-        "Namespace used to create action server, also determines what model to load.  Ex: depth, depth_and_tactile"
+        help= "Namespace used to create action server, also determines what model to load.  Ex: depth, depth_and_tactile"
     )
     parser.add_argument(
         "--flip_batch_x",
@@ -211,17 +210,13 @@ if __name__ == "__main__":
         "Z+ should be extending away from the camera, sometime binvox files have this as Y+ and need to be rotated. "
     )
     parser.add_argument(
-        "__log",
+        "roslaunch arguments",
         type=str,
+        default=" ",
+        nargs=*,
         help=
         ""
     )
-    parser.add_argument(
-        "__name",
-        type=str,
-        help=
-        ""
-    )    
     args = parser.parse_args()
     cnns = {
         "depth": {

--- a/scripts/shape_completion_server/mesh_completion_server.py
+++ b/scripts/shape_completion_server/mesh_completion_server.py
@@ -210,6 +210,18 @@ if __name__ == "__main__":
         help=
         "Z+ should be extending away from the camera, sometime binvox files have this as Y+ and need to be rotated. "
     )
+    parser.add_argument(
+        "__log",
+        type=str,
+        help=
+        ""
+    )
+    parser.add_argument(
+        "__name",
+        type=str,
+        help=
+        ""
+    )    
     args = parser.parse_args()
     cnns = {
         "depth": {

--- a/scripts/shape_completion_server/mesh_completion_server.py
+++ b/scripts/shape_completion_server/mesh_completion_server.py
@@ -222,14 +222,14 @@ if __name__ == "__main__":
     cnns = {
         "depth": {
             "cnn_python_module":
-            "shape_completion_server.trained_models.depth_y17_m05_d26_h14_m22_s35_bare_keras_v2.reconstruction_network",
+            "trained_models.depth_y17_m05_d26_h14_m22_s35_bare_keras_v2.reconstruction_network",
             "weights_filepath":
             rospkg.RosPack().get_path('pc_object_completion_cnn') +
             '/scripts/shape_completion_server/trained_models/depth_y17_m05_d26_h14_m22_s35_bare_keras_v2/best_weights.h5'
         },
         "depth_and_tactile": {
             "cnn_python_module":
-            "shape_completion_server.trained_models.depth_and_tactile_y17_m08_d09_h15_m55_s53_bare_keras_v2.reconstruction_network",
+            "trained_models.depth_and_tactile_y17_m08_d09_h15_m55_s53_bare_keras_v2.reconstruction_network",
             "weights_filepath":
             rospkg.RosPack().get_path('pc_object_completion_cnn') +
             '/scripts/shape_completion_server/trained_models/depth_and_tactile_y17_m08_d09_h15_m55_s53_bare_keras_v2/best_weights.h5'


### PR DESCRIPTION
The `mesh_completion_server` module didn't handle the arguments passed to it by roslaunch. I adapted  the argparse setup slightly to solve it. The `ns` parameters is not optional and requires `-ns` as a flag.

Furthermore `mesh_completion_server` wouldn't find the path to the `reconstruction_network` module, this has been fixed.